### PR TITLE
Allow extensions to be loaded individually

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ RDoc[http://rubydoc.info/github/splattael/minitest-around/master/file/README.rdo
 === Unit tests
 
   require 'minitest/autorun'
-  require 'minitest/around'
+  require 'minitest/around/unit'
   require 'thread'
 
   class MutexTest < MiniTest::Unit::TestCase
@@ -43,7 +43,7 @@ RDoc[http://rubydoc.info/github/splattael/minitest-around/master/file/README.rdo
 === Spec
 
   require 'minitest/autorun'
-  require 'minitest/around'
+  require 'minitest/around/spec'
   require 'thread'
 
   describe "Mutex" do

--- a/lib/minitest/around.rb
+++ b/lib/minitest/around.rb
@@ -1,23 +1,3 @@
 require 'minitest/around/version'
-
-class MiniTest::Unit::TestCase
-  def run_test(name)
-    if defined?(around)
-      around { |*args| __send__(name, *args) }
-    else
-      __send__(name)
-    end
-  end
-end
-
-class MiniTest::Spec
-  def self.around(&outer)
-    define_method(:around) do |&inner|
-      if outer.arity == 1
-        outer.call(inner)
-      else
-        inner.call *outer.call
-      end
-    end
-  end
-end
+require 'minitest/around/spec'
+require 'minitest/around/unit'

--- a/lib/minitest/around/spec.rb
+++ b/lib/minitest/around/spec.rb
@@ -1,0 +1,11 @@
+class MiniTest::Spec
+  def self.around(&outer)
+    define_method(:around) do |&inner|
+      if outer.arity == 1
+        outer.call(inner)
+      else
+        inner.call *outer.call
+      end
+    end
+  end
+end

--- a/lib/minitest/around/unit.rb
+++ b/lib/minitest/around/unit.rb
@@ -1,0 +1,9 @@
+class MiniTest::Unit::TestCase
+  def run_test(name)
+    if defined?(around)
+      around { |*args| __send__(name, *args) }
+    else
+      __send__(name)
+    end
+  end
+end


### PR DESCRIPTION
fixes:

```
gems/minitest-around-0.0.1/lib/minitest/around.rb:3:in
`<top (required)>': uninitialized constant MiniTest::Unit (NameError)
```

when exclusively loading minitest/spec
