### PR TITLE
Wrap spec method in DSL module.

### DIFF
--- a/lib/minitest/around/spec.rb
+++ b/lib/minitest/around/spec.rb
@@ -4,12 +4,14 @@ require 'minitest/around/version'
 require 'minitest/around/unit'
 
 class MiniTest::Spec
-  def self.around(&outer)
-    define_method(:around) do |&inner|
-      if outer.arity == 1
-        outer.call(inner)
-      else
-        inner.call *outer.call
+  module DSL
+    def around(&outer)
+      define_method(:around) do |&inner|
+        if outer.arity == 1
+          outer.call(inner)
+        else
+          inner.call *outer.call
+        end
       end
     end
   end


### PR DESCRIPTION
MiniTest 4.7.x introduced the DSL module and minitest-spec-rails (among others) use it. I can't use this extension with minitest-spec-rails without this change. All tests pass and the README on this project already says that it requires 4.7.x so I think we're good to go. See metaskills/minitest-spec-rails#32 for more details.
