### PR TITLE
make sure paths are correct

### DIFF
--- a/test/around_spec.rb
+++ b/test/around_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative 'helper'
 require 'minitest/around/spec'
 
 describe "Minitest Around" do

--- a/test/around_test.rb
+++ b/test/around_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative 'helper'
 require 'minitest/around/unit'
 
 class TestWithoutAround < Minitest::Test

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,2 @@
+require 'bundler/setup'
+require 'minitest/autorun'

--- a/test/nested_spec.rb
+++ b/test/nested_spec.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative 'helper'
 require 'minitest/around'
 
 $var = []

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -1,4 +1,4 @@
-require 'minitest/autorun'
+require_relative 'helper'
 require 'minitest/around/unit'
 
 $var = []


### PR DESCRIPTION
prevents fun things like this + makes sure we are always in the bundle

```
ruby test/nested_spec.rb
cannot load such file -- minitest/around (LoadError)
```

@splattael
