### PR TITLE
avoid dead fiber called errors

### DIFF
--- a/test/around_spec.rb
+++ b/test/around_spec.rb
@@ -67,4 +67,24 @@ describe "Minitest Around" do
       end
     end
   end
+
+  describe "fail" do
+    it "does not fail with fiber error" do
+      Tempfile.open("XX") do |f|
+        f.write <<-RUBY
+          require "#{File.expand_path("../helper", __FILE__)}"
+          require 'minitest/around/spec'
+          describe "x" do
+            around { raise ArgumentError }
+            after { puts "AFTER" }
+            it("x") { }
+          end
+        RUBY
+        f.close
+        output = `ruby #{f.path}`
+        output.must_include "ArgumentError: ArgumentError"
+        output.wont_include "FiberError"
+      end
+    end
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,2 +1,3 @@
 require 'bundler/setup'
+require 'tempfile'
 require 'minitest/autorun'


### PR DESCRIPTION
@splattael

when the fiber dies after is still called -> Dead fiber error

only other bug I found is that the Thread is no longer the main thread, so things like Thread.current[:xxx] are suddenly nil ...
