### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # minitest-around
 
-[![Build Status](https://travis-ci.org/splattael/minitest-around.png)](https://travis-ci.org/splattael/minitest-around) [![Inline docs](http://inch-pages.github.io/github/splattael/minitest-around.png)](http://inch-pages.github.io/github/splattael/minitest-around)
+[![Build Status](https://travis-ci.org/splattael/minitest-around.png)](https://travis-ci.org/splattael/minitest-around) [![Inline docs](http://inch-ci.org/github/splattael/minitest-around.png)](http://inch-ci.org/github/splattael/minitest-around)
 
 Around block for minitest 5.X.
 


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
