### PR TITLE
do not declare classes when they do not exist

### DIFF
--- a/lib/minitest/around/spec.rb
+++ b/lib/minitest/around/spec.rb
@@ -3,34 +3,32 @@ require 'minitest'
 require 'minitest/around/version'
 require 'minitest/around/unit'
 
-class Minitest::Spec
-  module DSL
-    # - resume to call first part
-    # - execute test
-    # - resume fiber to execute last part
-    def around(&block)
-      fib = nil
-      before do
-        fib = Fiber.new do |context, resume|
-          begin
-            context.instance_exec(resume, &block)
-          rescue Object
-            fib = :failed
-            raise
-          end
+Minitest::Spec::DSL.class_eval do
+  # - resume to call first part
+  # - execute test
+  # - resume fiber to execute last part
+  def around(&block)
+    fib = nil
+    before do
+      fib = Fiber.new do |context, resume|
+        begin
+          context.instance_exec(resume, &block)
+        rescue Object
+          fib = :failed
+          raise
         end
-        fib.resume(self, lambda { Fiber.yield })
       end
-      after  { fib.resume unless fib == :failed }
+      fib.resume(self, lambda { Fiber.yield })
     end
+    after  { fib.resume unless fib == :failed }
+  end
 
-    # Minitest does not support multiple before/after blocks
-    def before(type=nil, &block)
-      include Module.new { define_method(:setup) { super(); instance_exec(&block) } }
-    end
+  # Minitest does not support multiple before/after blocks
+  def before(type=nil, &block)
+    include Module.new { define_method(:setup) { super(); instance_exec(&block) } }
+  end
 
-    def after(type=nil, &block)
-      include Module.new { define_method(:teardown) { instance_exec(&block); super() } }
-    end
+  def after(type=nil, &block)
+    include Module.new { define_method(:teardown) { instance_exec(&block); super() } }
   end
 end

--- a/lib/minitest/around/unit.rb
+++ b/lib/minitest/around/unit.rb
@@ -1,7 +1,7 @@
 require 'minitest'
 require 'minitest/around/version'
 
-class Minitest::Test
+Minitest::Test.class_eval do
   alias_method :run_without_around, :run
   def run(*args)
     if defined?(around)


### PR DESCRIPTION
@splattael 

more of a theoretical problem, but kind of nice to have in case minitest decides to somehow rename their classes -> blows up instead of defining new classes
