### PR TITLE
Fix uninitialized constant Minitest::Spec (NameError) in rails

### DIFF
--- a/lib/minitest/around/spec.rb
+++ b/lib/minitest/around/spec.rb
@@ -1,4 +1,5 @@
 require 'minitest'
+require 'minitest/spec'
 
 require 'minitest/around/version'
 require 'minitest/around/unit'

--- a/lib/minitest/around/unit.rb
+++ b/lib/minitest/around/unit.rb
@@ -1,4 +1,6 @@
 require 'minitest'
+require 'minitest/test'
+
 require 'minitest/around/version'
 
 Minitest::Test.class_eval do


### PR DESCRIPTION
**Description:**

This fixes error `uninitialized constant Minitest::Spec (NameError)` when I use this gem in my rails app.

**Stack Trace:**

/Users/hendrauzia/sandbox/[redacted]/.bundle/gems/minitest-around-0.3.0/lib/minitest/around/spec.rb:6:in `<top (required)>': uninitialized constant Minitest::Spec (NameError)
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/minitest-around-0.3.0/lib/minitest/around.rb:2:in `require'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/minitest-around-0.3.0/lib/minitest/around.rb:2:in `<top (required)>'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:85:in `require'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:85:in `rescue in block in require'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:68:in `block in require'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:61:in `each'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler/runtime.rb:61:in `require'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/bundler-1.7.12/lib/bundler.rb:134:in `require'
	from /Users/hendrauzia/sandbox/[redacted]/config/application.rb:15:in `<top (required)>'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:82:in `require'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:82:in `preload'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:143:in `serve'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:131:in `block in run'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:125:in `loop'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application.rb:125:in `run'
	from /Users/hendrauzia/sandbox/[redacted]/.bundle/gems/spring-1.3.1/lib/spring/application/boot.rb:18:in `<top (required)>'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/hendrauzia/.rbenv/versions/2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from -e:1:in `<main>'