### PR TITLE
Remove reference to examples directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ gem install minitest-around
 
 ## Usage
 
-See [examples](/examples) directory for some example usage..
-
 ### Unit tests
 
 ```Ruby


### PR DESCRIPTION
The current README refers to the _examples_ directory for usage examples, but this pointer is useless because the only file there has this code:

```ruby
code = File.read("README.md")[%r{<!-- example -->(.*)<!-- example -->}m].split("\n")[2..-3].join("\n")
puts code
eval code
```

1. This is not readable for usage examples purposes.
2. Obviously, examples executed there are already present in the README.