### PR TITLE
run ensure blocks of around hooks when a after block fails

### DIFF
--- a/lib/minitest/around/spec.rb
+++ b/lib/minitest/around/spec.rb
@@ -31,6 +31,14 @@ Minitest::Spec::DSL.class_eval do
 
   remove_method :after
   def after(type=nil, &block)
-    include Module.new { define_method(:teardown) { instance_exec(&block); super() } }
+    include(Module.new do
+      define_method(:teardown) do
+        begin
+          instance_exec(&block)
+        ensure
+          super()
+        end
+      end
+    end)
   end
 end

--- a/test/around_spec.rb
+++ b/test/around_spec.rb
@@ -98,7 +98,6 @@ describe "Minitest Around" do
           it("x") {}
         end
       RUBY
-
       output.must_include("ENSURE")
     end
   end

--- a/test/around_spec.rb
+++ b/test/around_spec.rb
@@ -82,6 +82,26 @@ describe "Minitest Around" do
       output.wont_include "FiberError"
     end
   end
+
+  describe "ensure blocks in around" do
+    it "runs the ensure block even if another teardown fails" do
+      output = spawn_test <<-RUBY
+        describe "x" do
+          around do |b|
+            begin
+              b.call
+            ensure
+              puts "ENSURE"
+            end
+          end
+          after { raise }
+          it("x") {}
+        end
+      RUBY
+
+      output.must_include("ENSURE")
+    end
+  end
 end
 
 def spawn_test(code)


### PR DESCRIPTION
replaces https://github.com/splattael/minitest-around/pull/33

around blocks are split into a before and after part by using fibers
... and ...
around hooks define multiple after blocks,
if one of the fails it does not call the other ones
results in:
when a after hooks fails the ensure is not executed

@splattael @jbodah 